### PR TITLE
Updates quadstore's record

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,10 +71,10 @@
           "description": "Lightning fast, spec-compatible, streaming RDF for JavaScript.",
           "implements": [ "DataFactory", "Sink" ]
         }, {
-          "@id": "https://github.com/beautifulinteractions/node-quadstore",
-          "name": "node-quadstore",
-          "description": "A LevelDB-backed graph database for Node.js and the browser supporting SPARQL queries and the RDF/JS interface.",
-          "implements": [ "Store" ]
+          "@id": "https://github.com/jacoscaz/quadstore",
+          "name": "quadstore",
+          "description": "An embedded and persistent graph database for JS runtimes (incl. browsers) supporting SPARQL queries and RDF/JS interfaces",
+          "implements": [ "Store", "Sink", "Source" ]
         }, {
           "@id": "https://github.com/blake-regalia/graphy.js",
           "name": "graphy",


### PR DESCRIPTION
Hi! This PR updates quadstore's record according to the following:

- name change (from `node-quadstore` to simply `quadstore`)
- url change (from `beautifujinteractions/quadstore` to `jacoscaz/quadstore`)
- complete list of supported RDF/JS interfaces (`Store`, `Sink`, `Source`)
- updated description